### PR TITLE
fix module missing error

### DIFF
--- a/lib/messenger_platform/engine.rb
+++ b/lib/messenger_platform/engine.rb
@@ -1,3 +1,5 @@
-class MessengerPlatform::Engine < ::Rails::Engine
-  isolate_namespace MessengerPlatform
+module MessengerPlatform
+  class Engine < ::Rails::Engine
+    isolate_namespace MessengerPlatform
+  end
 end


### PR DESCRIPTION
After including this Gem in my project, and working around issue #23 I
then encountered this error:

> messenger_platform/engine.rb:1:in `<top (required)>':
> uninitialized constant MessengerPlatform (NameError)

Fix it by separating the module declaration from the class declaration
to ensure the module exists before the class definition.
